### PR TITLE
Remove left-over docker containers before fixing permissions

### DIFF
--- a/cloud-init.yml
+++ b/cloud-init.yml
@@ -120,6 +120,9 @@ write_files:
   - path: /usr/local/sbin/runner-cleanup-workdir.sh
     content: |
       #!/bin/bash
+      echo "Left-over containers:"
+      docker ps -a
+      docker ps -qa | xargs --verbose --no-run-if-empty docker rm -fv
 
       if [[ -d ~runner/actions-runner/_work/airflow/airflow ]]; then
         cd ~runner/actions-runner/_work/airflow/airflow
@@ -133,7 +136,6 @@ write_files:
             git clean -fxd \
           "
         fi
-        docker ps -qa | xargs --no-run-if-empty docker rm -fv
       fi
     owner: root:root
     permissions: '0775'


### PR DESCRIPTION
If the docker container is still running and creating files (as might be the case for the prod image builds) then some files could be left uncleaned, causing the next job to fail.

Fixes apache/airflow#14505