### PR TITLE
Add an environment variable to let runners know where they are running

### DIFF
--- a/cloud-init.yml
+++ b/cloud-init.yml
@@ -39,6 +39,8 @@ runcmd:
     - |
       set -exu -o pipefail
       echo "AWS_DEFAULT_REGION=$(cloud-init query region)" >> /etc/environment
+      # Set an env var (that is visible in runners) that will let us know we are on a self-hosted runner
+      echo 'AIRFLOW_SELF_HOSTED_RUNNER="[\"self-hosted\"]"' >> /etc/environment
       set -a
       . /etc/environment
       set +a


### PR DESCRIPTION
This makes it easier to set runs-on in our ci.yml workflow -- see apache/airflow#14718