### PR TITLE
Strip ANSI escape codes from logs in CloudWatch

### DIFF
--- a/cloud-init.yml
+++ b/cloud-init.yml
@@ -288,6 +288,7 @@ write_files:
 
           if err == null {
             . = merge(., structured)
+            .message = strip_ansi_escape_codes!(.message)
             .type = "job-output"
           }
         '''


### PR DESCRIPTION
Now that we are included step logs, we need to strip the colour escape
sequences.