### PR TITLE
Update actions.runner to 2.277.1-airflow3

### DIFF
--- a/cloud-init.yml
+++ b/cloud-init.yml
@@ -80,7 +80,7 @@ runcmd:
       aws ssm get-parameter --with-decryption --name /runners/apache/airflow/dockerPassword | \
         jq .Parameter.Value -r | \
         sudo -u runner docker login --username airflowcirunners --password-stdin
-    - 2.277.1-airflow1
+    - 2.277.1-airflow3
   - [systemctl, enable, --now, iptables.service]
   # Restart docker after applying the user firewall -- else some rules/chains might be list!
   - [systemctl, restart, docker.service]


### PR DESCRIPTION
This included extra logging and uses `github.actor`, rather than
`github.pull_request.author` for decisions (to match what we use in our
CI.yml file).