### PR TITLE
Cleanup logs and "build state" from the AMI

### DIFF
--- a/github-runner-ami/packer/files/cleanup.sh
+++ b/github-runner-ami/packer/files/cleanup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -ex
+
+rm ~ubuntu/.ssh/authorized_keys
+
+journalctl --rotate
+sleep 2
+journalctl --vacuum-time=1s
+
+rm -rf /var/lib/cloud/ /var/log/cloud-init*.log
+
+rm -rf /var/cache/* /var/lib/apt/*

--- a/github-runner-ami/packer/ubuntu2004.pkr.hcl
+++ b/github-runner-ami/packer/ubuntu2004.pkr.hcl
@@ -139,6 +139,7 @@ build {
       "./files/install-dependencies.sh",
       "./files/docker-compose.sh",
       "./files/runner_bootstrap.sh",
+      "./files/cleanup.sh",
     ]
     execute_command = "chmod +x '{{ .Path }}'; sudo sh -c '{{ .Vars }} {{ .Path }}'"
     environment_vars = [


### PR DESCRIPTION
Not doing this doesn't cause any harm, but it is cleaner to not have
this state included in the AMI