### PR TITLE
Don't kill Runner.Listener when steps running

### DIFF
--- a/github-runner-ami/packer/files/stop-runner-if-no-job.sh
+++ b/github-runner-ami/packer/files/stop-runner-if-no-job.sh
@@ -31,13 +31,17 @@ if pgrep --ns $MAINPID -a Runner.Worker > /dev/null; then
     # Job running -- just wait for it to exit
     sleep 10
   done
+
+else
+  # If there were _no_ Workers running, ask the main process to stop. If there
+  # were Workers running, then Runner.Listener would stop automatically because
+  # of the `--once`
+  pkill --ns $MAINPID Runner.Listener || true
 fi
 
-# Request shutdown if it's still alive -- because we are in "stop" state it should not restart
-if pkill --ns $MAINPID Runner.Listener; then
   # Wait for it to shut down
-  echo "Waiting for main Runner.Listener process to stop"
-  while pgrep --ns $MAINPID -a Runner.Listener; do
-    sleep 5
-  done
+echo "Waiting for main Runner.Listener process to stop"
+while pgrep --ns $MAINPID -a Runner.Listener; do
+  sleep 5
+done
 fi


### PR DESCRIPTION
Because of the `--once` flag we already pass to the deamon, _if_ there
were any jobs running, then the main actions-runner deamon (the
Runner.Listener process) will shut it self down once it's _actually_
finished.

So we want to avoid the `pkill Runner.Listener` in the case when a step
was executing, as otherwise we will likely kill the deamon before it has
a chance to complete the job/report back to GitHub/run the next step.