### PR TITLE
Fix syntax error in stop-runner-if-no-job.sh

### DIFF
--- a/github-runner-ami/packer/files/stop-runner-if-no-job.sh
+++ b/github-runner-ami/packer/files/stop-runner-if-no-job.sh
@@ -40,8 +40,7 @@ else
 fi
 
   # Wait for it to shut down
-echo "Waiting for main Runner.Listener process to stop"
+echo "Waiting for main Runner.Listener $MAINPID process to stop"
 while pgrep --ns $MAINPID -a Runner.Listener; do
   sleep 5
 done
-fi


### PR DESCRIPTION
This trailing `fi` on the end would likely cause the Runner.Listener to
be terminated to early.