### PR TITLE
Allow more time for runner to stop before terminating

### DIFF
--- a/github-runner-ami/packer/files/actions.runner.service
+++ b/github-runner-ami/packer/files/actions.runner.service
@@ -31,7 +31,7 @@ User=runner
 WorkingDirectory=/home/runner/actions-runner
 KillMode=mixed
 KillSignal=SIGTERM
-TimeoutStopSec=5min
+TimeoutStopSec=30min
 Restart=on-success
 
 [Install]


### PR DESCRIPTION
With this timeout at 5 minutes, it means that any running jobs only had
5 minutes to complete before the runner would be killed and the instance
terminated.

Hopefully by increasing this we should reduce/entirely remove the
"communication lost with runner" errors in our self-hosted builds