### PR TITLE
Update to vector 0.15 syntax

### DIFF
--- a/github-runner-ami/packer/files/install-dependencies.sh
+++ b/github-runner-ami/packer/files/install-dependencies.sh
@@ -39,8 +39,11 @@ apt-get install -yq --no-install-recommends -o Dpkg::Options::="--force-confold"
             python3-venv \
             python3-wheel \
             yarn \
-            vector
+            vector='0.15.*'
 
 
 # Re-enabled in clout-init once AWS_DEFAULT_REGION env var is set
 systemctl disable vector
+
+# validate the vector config file we have already installed
+sudo -u vector vector validate --no-environment

--- a/github-runner-ami/packer/files/vector.toml
+++ b/github-runner-ami/packer/files/vector.toml
@@ -59,8 +59,7 @@ data_dir = "/var/lib/vector"
 [transforms.filter-runner-logs]
   type = "filter"
   inputs = ['grok-runner-logs']
-  condition.type = "remap"
-  condition.source = '''
+  condition = '''
     if .logger == "JobServerQueue" {
       !match!(.message, r'Try to append \d+ batches web console lines for record')
     } else if .logger == "HostContext" {


### PR DESCRIPTION
Vector 0.15 had a breaking change that stopped our config working, so
rather than only noticing at run time, fail at build time