### PR TITLE
Temporary fix docker-compose to 1.29.2

### DIFF
--- a/github-runner-ami/packer/files/docker-compose.sh
+++ b/github-runner-ami/packer/files/docker-compose.sh
@@ -20,6 +20,15 @@
 set -exu -o pipefail
 
 # https://github.com/actions/virtual-environments/blob/525f79f479cca77aef4e0a680548b65534c64a18/images/linux/scripts/installers/docker-compose.sh
-URL=$(curl -s https://api.github.com/repos/docker/compose/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("docker-compose-linux-x86_64"))')
-curl --fail -L "$URL" -o /usr/local/bin/docker-compose
+
+# disabled installing latest released version until https://github.com/docker/compose/issues/8742
+# is solved (docker v2 breaks network management required to get kerberos integration working
+# Switching temporary to latest released docker v2
+
+#URL=$(curl -s https://api.github.com/repos/docker/compose/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("docker-compose-linux-x86_64"))')
+#curl --fail -L "$URL" -o /usr/local/bin/docker-compose
+#chmod +x /usr/local/bin/docker-compose
+
+# Hard-code docker-compose 1.29.2
+curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 chmod +x /usr/local/bin/docker-compose

--- a/github-runner-ami/packer/ubuntu2004.pkr.hcl
+++ b/github-runner-ami/packer/ubuntu2004.pkr.hcl
@@ -38,7 +38,7 @@ source "amazon-ebs" "runner_builder" {
   #access_key = ""
   #secret_key = ""
   region = var.aws_regions[0]
-  ami_name = "${var.ami_name}-${var.runner_version}"
+  ami_name = "${var.ami_name}-${var.runner_version}-v2"
   ami_regions = var.aws_regions
   tag {
     key   = "Name"


### PR DESCRIPTION
Docker-compose 2 breaks kerberos integration and we need to
hard-code 1.29.2 temporarily until
https://github.com/docker/compose/issues/8742 is solved