### PR TITLE
Add script to list out committers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .cache
 __pycache__/
+.mypy_cache
 
 # Created by https://www.toptal.com/developers/gitignore/api/terraform
 # Edit at https://www.toptal.com/developers/gitignore?templates=terraform

--- a/scripts/list_committers
+++ b/scripts/list_committers
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import click
+from github import Github
+
+
+@click.command(short_help='List committer logins - used to sync list of committers in CI configuration')
+@click.argument('github-token', envvar='GITHUB_TOKEN')
+def main(github_token):
+    gh = Github(github_token)
+    org = gh.get_organization('apache')
+    committers = org.get_team_by_slug('airflow-committers')
+    committer_usernames = sorted(f'"{c.login}"' for c in committers.get_members())
+
+    click.echo("Take the below list and:")
+    click.echo(
+        " - replace the list of commiters in the `build-info` job in apache/airflow's `.github/workflows/ci.yml`"
+    )
+    click.echo(" - update the `/runners/apache/airflow/configOverlay` parameter in AWS SSM ParameterStore\n")
+    click.echo(',\n'.join(committer_usernames))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I discovered our list of committers was out of date, and instead of manually reconciling it, I wrote this quick script to generate it (less error prone 😀).