### PR TITLE
Add a file listing trusted code authors

### DIFF
--- a/authors.toml
+++ b/authors.toml
@@ -1,0 +1,56 @@
+# For security, CI jobs triggered by a GitHub pull request should only run on
+# Airflow infra when they are from a user that is in this list.
+# 
+# This list consists of the airflow committers and other known, trusted
+# authors. Currently maintained by hand; and the AWS SSM parameter is still
+# the source of truth, so changes here must also be replicated there.
+
+[core]
+BasPH = ""
+Fokko = ""
+KevinYang21 = ""
+XD-DENG = "Xiaodong DENG"
+aijamalnk= "Aizhamal Nurmamat kyzy"
+alexvanboxel = ""
+aoen = ""
+artwr = ""
+ashb = ""
+bbovenzi = ""
+bolkedebruin = ""
+criccomini = ""
+dimberman = ""
+dstandish = "Daniel Standish"
+eladkal = ""
+ephraimbuddy = ""
+feluelle = "Felix Uellendall"
+feng-tao = ""
+houqp = ""
+jedcunningham = "Jed Cunningham"
+jgao54 = "Joy Gao"
+jghoman = ""
+jhtimmins = ""
+jmcarp = ""
+josh-fell = "Josh Fell"
+kaxil = "Kaxil Naik"
+leahecole = ""
+malthe = ""
+mik-laj = "Kamil Breguła"
+milton0825 = ""
+mistercrunch = ""
+msumit = ""
+pingzh = "Ping Zhang"
+potiuk = ""
+r39132 = ""
+ryanahamilton = ""
+ryw = ""
+saguziel = ""
+sekikn = ""
+turbaszek = "Tomek Urbaszek"
+uranusjr = ""
+vikramkoka = "Vikram Koka"
+xinbinhuang = "Xinbin Huang"
+yuqian90 = ""
+zhongjiajie = "Jiajie Zhong"
+
+[pleb]
+norm = "Mark Norman Francis"


### PR DESCRIPTION
In order to sync the list of authors in the airflow repo's `ci.yml` who can have their PR jobs run on airflow's infra with the truth of the matter, there should be a source of truth that can be seen without special permissions.

1. Make this list available (although not yet a source of truth). That's this PR.
2. Create a Github Action on `apache/airflow` that will pull the list from this repo and commit changes back. That comes once this is merged.
3. Make this list authoritative by having it become a source of truth and changes to it trigger updates to SSM. That comes … later.