### PR TITLE
Increase amount of memory available for tests in self-hosted runners ??

### DIFF
--- a/github-runner-ami/packer/files/mounts_setup.sh
+++ b/github-runner-ami/packer/files/mounts_setup.sh
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-sudo mount -t tmpfs -o size=85% tmpfs /var/lib/docker
+sudo mount -t tmpfs -o size=75% tmpfs /var/lib/docker
 sudo mount -t tmpfs -o tmpfs /home/runner/actions-runner/_work


### PR DESCRIPTION
Our self-hosted runners have a lot of memory allocated to the /var/lib/docker which is tmpfs mounted storage for docker engine.

This is done in order to speed up immensely any docker-related operations - such as building and creating images and running and deploying kubernetes instances.

The memory allocated was at the 85% of capacity ~ 52 GB. However it seems that with our setup when we run up to two full K8S clusters, we are peaking at ~40GB . We can safely allocate more memory for tests and other operations - which might speed up the speed of tests.

Update: After reading a bit, I think it will not gain us much because it looks like `tmpfs` will only use as much memory as it actually uses, it does not reserve the whole amount available.
